### PR TITLE
Add support to strip html from ical files, and give the option for the other formats

### DIFF
--- a/lib/add_to_calendar/version.rb
+++ b/lib/add_to_calendar/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module AddToCalendar
-  VERSION = "0.2.5"
+  VERSION = '0.3'
 end

--- a/test/urls/dates_test.rb
+++ b/test/urls/dates_test.rb
@@ -13,7 +13,6 @@ class DatessTest < Minitest::Test
 
     @tz_london = "Europe/London"
     @tz_new_york = "America/New_York"
-
   end
   
   def test_utc_datetime


### PR DESCRIPTION
Ical doesn't support html in descriptions, so it just displays all tags in the description.

It's a common use case to pass a rich text to a description, and would like the library to remove it for iCal, but allow the other formats to display the rich text